### PR TITLE
Created update-tests script to pull latest A1 Postman collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "api-test": "npm run newman && npm run newman >> reports/api-report.txt",
-    "test": "newman run collection.json -e environment.json; return 0;"
+    "test": "newman run collection.json -e environment.json; return 0;",
+    "update-tests": "curl -L -o collection.json https://www.getpostman.com/collections/583570-b1c26430-4a62-4a99-ab10-4fb6f81c5622"
+
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -1,31 +1,35 @@
-[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/uwidcit/info2602a1) 
+# [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/uwidcit/info2602a1)
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://documenter.getpostman.com/view/583570/SzRuZCp8?version=latest)
 
+## Initializing
 
-# Initializing
-You can initialize your database according to the init command in wsgi.py by running the following command
+You can initialize your database according to the init command in wsgi.py by running the following command:
 
-```
+```bash
 flask init
 ```
-It is a good idea to run this after every change to models
 
-# Running
+It is a good idea to run this after every change to models.
+
+## Running
+
 When opened in gitpod the server should be running already if it isn't
-you can start it with the following command;
+you can start it with the following command:
 
 ```bash
 flask run
 ```
 
-# Testing
-1. Ensure postman is setup to point to your assignment's gitpod url as the host variable.
-2. Test your application by running the requests of the postman collection linked above and viewing the Test Results tab
+## Testing
+
+1. To ensure the latest version of the test suite is downloaded, run: ```npm run update-tests```
+2. Ensure Postman is setup to point to your assignment's Gitpod url as the host variable.
+3. Test your application by running the requests of the Postman collection linked above and viewing the Test Results tab
 
 ![results](/img/results.png)
 
-When all of you routes are implemented you can run the entire collection of tests.
+When all of your routes are implemented you can run the entire collection of tests.
 
 ![run 1](/img/run.png)
 


### PR DESCRIPTION
Instead of creating a new Gitpod workspace or manually exporting `collection.json` to incorporate the latest tests collection, students can now run
```bash
npm run update-tests
```
to download the latest version and see immediate results with ```npm test```